### PR TITLE
終了通知が出ない不具合の修正

### DIFF
--- a/params.py
+++ b/params.py
@@ -6,6 +6,6 @@ INITIAL_FLAG = True
 
 channel_id = INITIAL_CHANNEL
 notitext = INITIAL_TEXT
-changeflag = INITIAL_FLAG
+is_call_end_notification_enabled = INITIAL_FLAG
 e_time = {}
 channelonoff = {}


### PR DESCRIPTION
changeflagをis_call_end_notification_enabledにリネーム